### PR TITLE
Remove make available button if status is stuck, show empty status if collection has no files

### DIFF
--- a/src/components/@Explore/CollectionDIDItemDetails.tsx
+++ b/src/components/@Explore/CollectionDIDItemDetails.tsx
@@ -130,7 +130,7 @@ const _CollectionDIDItemDetails: React.FC<DIDItem> = ({ did, ...props }) => {
       {collectionState === 'PARTIALLY_AVAILABLE' && <FilePartiallyAvailable onMakeAvailableClicked={makeAvailable} />}
       {collectionState === 'NOT_AVAILABLE' && <FileNotAvailable onMakeAvailableClicked={makeAvailable} />}
       {collectionState === 'REPLICATING' && <FileReplicating did={did} />}
-      {collectionState === 'STUCK' && <FileStuck onMakeAvailableClicked={makeAvailable} />}
+      {collectionState === 'STUCK' && <FileStuck />}
     </div>
   );
 };
@@ -197,16 +197,13 @@ const FileReplicating: React.FC<{ did: string }> = ({ did }) => {
   );
 };
 
-const FileStuck: React.FC<{ onMakeAvailableClicked?: { (): void } }> = ({ onMakeAvailableClicked }) => {
+const FileStuck: React.FC = () => {
   const classes = useStyles();
 
   return (
     <div className={classes.statusNotAvailable}>
       <i className={`${classes.icon} material-icons`}>error</i>
       <div className={classes.statusText}>Something went wrong</div>
-      <div className={classes.action} onClick={onMakeAvailableClicked}>
-        Make Available
-      </div>
     </div>
   );
 };

--- a/src/components/@Explore/CollectionDIDItemDetails.tsx
+++ b/src/components/@Explore/CollectionDIDItemDetails.tsx
@@ -57,6 +57,10 @@ const useStyles = createUseStyles({
     extend: 'statusContainer',
     color: 'var(--jp-rucio-yellow-color)'
   },
+  statusEmpty: {
+    extend: 'statusContainer',
+    color: 'var(--jp-rucio-yellow-color)'
+  },
   statusNotAvailable: {
     extend: 'statusContainer',
     color: 'var(--jp-error-color1)'
@@ -131,6 +135,7 @@ const _CollectionDIDItemDetails: React.FC<DIDItem> = ({ did, ...props }) => {
       {collectionState === 'NOT_AVAILABLE' && <FileNotAvailable onMakeAvailableClicked={makeAvailable} />}
       {collectionState === 'REPLICATING' && <FileReplicating did={did} />}
       {collectionState === 'STUCK' && <FileStuck />}
+      {collectionState === 'EMPTY' && <FileEmpty />}
     </div>
   );
 };
@@ -204,6 +209,17 @@ const FileStuck: React.FC = () => {
     <div className={classes.statusNotAvailable}>
       <i className={`${classes.icon} material-icons`}>error</i>
       <div className={classes.statusText}>Something went wrong</div>
+    </div>
+  );
+};
+
+const FileEmpty: React.FC = () => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.statusEmpty}>
+      <i className={`${classes.icon} material-icons`}>warning</i>
+      <div className={classes.statusText}>Collection is empty</div>
     </div>
   );
 };

--- a/src/components/@Explore/FileDIDItemDetails.tsx
+++ b/src/components/@Explore/FileDIDItemDetails.tsx
@@ -118,7 +118,7 @@ const _FileDIDItemDetails: React.FC<DIDItem> = ({ did, ...props }) => {
       {!!fileDetails && fileDetails.status === 'OK' && fileDetails.path && <FileAvailable did={did} path={fileDetails.path} />}
       {!!fileDetails && fileDetails.status === 'NOT_AVAILABLE' && <FileNotAvailable onMakeAvailableClicked={makeAvailable} />}
       {!!fileDetails && fileDetails.status === 'REPLICATING' && <FileReplicating did={did} />}
-      {!!fileDetails && fileDetails.status === 'STUCK' && <FileStuck onMakeAvailableClicked={makeAvailable} />}
+      {!!fileDetails && fileDetails.status === 'STUCK' && <FileStuck />}
     </div>
   );
 };
@@ -169,16 +169,13 @@ const FileReplicating: React.FC<{ did: string }> = ({ did }) => {
   );
 };
 
-const FileStuck: React.FC<{ onMakeAvailableClicked?: { (): void } }> = ({ onMakeAvailableClicked }) => {
+const FileStuck: React.FC = () => {
   const classes = useStyles();
 
   return (
     <div className={classes.statusNotAvailable}>
       <i className={`${classes.icon} material-icons`}>error</i>
       <div className={classes.statusText}>Something went wrong</div>
-      <div className={classes.action} onClick={onMakeAvailableClicked}>
-        Make Available
-      </div>
     </div>
   );
 };

--- a/src/components/@Notebook/NotebookAttachmentListItem.tsx
+++ b/src/components/@Notebook/NotebookAttachmentListItem.tsx
@@ -131,9 +131,9 @@ const _NotebookAttachmentListItem: React.FC<NotebookAttachmentListItemProps> = (
 
   const shouldDisplayMakeAvailableButton = (() => {
     if (fileDetails) {
-      return fileDetails.status === 'STUCK' || fileDetails.status === 'NOT_AVAILABLE';
+      return fileDetails.status === 'NOT_AVAILABLE';
     } else if (collectionState) {
-      return collectionState === 'STUCK' || collectionState === 'NOT_AVAILABLE' || collectionState === 'PARTIALLY_AVAILABLE';
+      return collectionState === 'NOT_AVAILABLE' || collectionState === 'PARTIALLY_AVAILABLE';
     }
 
     return false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,7 +68,7 @@ export interface DirectoryItem {
 }
 
 export type FileStatus = 'OK' | 'REPLICATING' | 'NOT_AVAILABLE' | 'STUCK';
-export type CollectionStatus = 'NOT_AVAILABLE' | 'AVAILABLE' | 'PARTIALLY_AVAILABLE' | 'REPLICATING' | 'STUCK';
+export type CollectionStatus = 'NOT_AVAILABLE' | 'AVAILABLE' | 'PARTIALLY_AVAILABLE' | 'REPLICATING' | 'STUCK' | 'EMPTY';
 export type ResolveStatus = 'NOT_RESOLVED' | 'RESOLVING' | 'PENDING_INJECTION' | 'READY' | 'FAILED';
 
 export type DIDSearchType = 'collection' | 'dataset' | 'container' | 'file' | 'all';

--- a/src/utils/Helpers.ts
+++ b/src/utils/Helpers.ts
@@ -17,7 +17,7 @@ export const computeCollectionState = (files?: FileDIDDetails[]): CollectionStat
   }
 
   if (files.length === 0) {
-    return 'AVAILABLE';
+    return 'EMPTY';
   }
 
   const available = files.find(file => file.status === 'OK');

--- a/tests/Helpers.test.ts
+++ b/tests/Helpers.test.ts
@@ -35,11 +35,11 @@ describe('toHumanReadableSize', () => {
 })
 
 describe('computeCollectionState', () => {
-    test('empty files should return AVAILABLE', () => {
+    test('empty files should return EMPTY', () => {
         const mockFiles: FileDIDDetails[] = [];
     
         const computedState = computeCollectionState(mockFiles);
-        expect(computedState).toBe('AVAILABLE');
+        expect(computedState).toBe('EMPTY');
     })
     
     test('null files should return false', () => {


### PR DESCRIPTION
- Stuck status should not have the option to make a new replication rule, so we take it out.
- However, make available button when status is stuck is useful on Download mode.
    - This will need to be sorted out
    - There needs to be a mechanism to let the frontend know which mode the extension is running in.
- If a collection is empty, show "empty" status instead of "available"