### PR TITLE
nodev16 to run playwright correct installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,12 @@ jobs:
         run: pytest rucio_jupyterlab/tests/
       - name: Run Pylint
         run: pylint --fail-under=8.5 rucio_jupyterlab/
+      - name: Install Node (for Playwright)
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
+      - name: Install Playwright
+        run: npx playwright install 
       - name: Build the extension
         run: |
           set -eux


### PR DESCRIPTION
The test workflow was failing as there was a change in the node code that was by default using a newer version (`v16`), which required a new package to be installed (`playwright`). 