### PR TITLE
update build and tag actions

### DIFF
--- a/.github/workflows/build-and-publish-tagged.yml
+++ b/.github/workflows/build-and-publish-tagged.yml
@@ -19,7 +19,8 @@ jobs:
           pip install build
           python -m build --sdist
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
+        permissions:
+          id-token: write
         with:
-          password: ${{ secrets.pypi_password }}
           skip_existing: true


### PR DESCRIPTION
For this action to work, a truster publisher must be added to the PyPi project [1 step how to](https://docs.pypi.org/trusted-publishers/adding-a-publisher/).

Version 0.9.9 of the package was never released and currently the package is installing 0.9.10. I would suggest to skip the patch version. 