### PR TITLE
fix: publish docker image in CI/CD #35

### DIFF
--- a/.github/workflows/build-and-publish-tagged.yml
+++ b/.github/workflows/build-and-publish-tagged.yml
@@ -2,7 +2,9 @@ name: Build and Publish Extension
 
 on:
   push:
-    tags: 'v*'
+    branches: 
+      - fix_ci_pypi
+    #tags: 'v*'
 
 jobs:
 
@@ -12,8 +14,14 @@ jobs:
   Build:
     needs: [Test]
     runs-on: ubuntu-latest
+
     permissions:
       id-token: write
+
+    environment:
+      name: # To be confirmed
+      url: https://pypi.org/project/rucio-jupyterlab/
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,4 +40,4 @@ jobs:
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          skip_existing: true
+          skipexisting: true


### PR DESCRIPTION
Publication of the package on test PyPI not working - using trusted publishing.

Tests have been done on the `ci_pypi_test` branch of my fork - [link to branch](https://github.com/garciagenrique/jupyterlab-extension/tree/ci_pypi_test).

Output of the CI [link](https://github.com/garciagenrique/jupyterlab-extension/actions/runs/13309020762/job/37166933772#step:6:230)

```bash

Uploading distributions to https://test.pypi.org/legacy/
INFO     dist/rucio_jupyterlab-1.1.0.tar.gz (357.3 KB)                          
INFO     username set by command options                                        
INFO     password set by command options                                        
INFO     username: __token__                                                    
INFO     password: <hidden>                                                     
Uploading rucio_jupyterlab-1.1.0.tar.gz
INFO     Response from https://test.pypi.org/legacy/:                           
         403 Forbidden                                                          
INFO     <html>                                                                 
          <head>                                                                
           <title>403 Invalid API Token: OIDC scoped token is not valid for     
         project 'rucio-jupyterlab', project-scoped token is not valid for      
         project: 'rucio-jupyterlab'</title>                                    
          </head>                                                               
          <body>                                                                
           <h1>403 Invalid API Token: OIDC scoped token is not valid for project
         'rucio-jupyterlab', project-scoped token is not valid for project:     
         'rucio-jupyterlab'</h1>                                                
           Access was denied to this resource.<br/><br/>                        
         Invalid API Token: OIDC scoped token is not valid for project          
         &#x27;rucio-jupyterlab&#x27;, project-scoped token is not valid for    
         project: &#x27;rucio-jupyterlab&#x27;                                  
                                                                                
                                                                                
          </body>                                                               
         </html>                                                                
ERROR    HTTPError: 403 Forbidden from https://test.pypi.org/legacy/            
         Forbidden                                                              
```

My guess after few CI tries is that the pypi project name `rucio-juputerlab` and the name of the repository `jupyterlab-extension` are the reason why the tokens are complaining. 

@ftorradeflot Could you double check, please ?