### PR TITLE
feat(ci): add dockerhub publish CI action #35

### DIFF
--- a/.github/workflows/build-and-publish-tagged.yml
+++ b/.github/workflows/build-and-publish-tagged.yml
@@ -33,3 +33,48 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip_existing: true
+
+  Build-docker:
+    needs: [Test]
+    runs-on: ubuntu-latest
+
+    permisions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log into the Docker Hub
+        id: login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata for the Docker image
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          flavor: |
+            latest=true
+          tags: |
+            type=semver,pattern={{raw}}
+          images: rucio/rucio-jupyterlab
+
+      - name: Build and push the Docker image
+        uses: docker/build-push-action@v6
+        id: docker_build
+        with:
+          context: .
+          file: ./docker/container/Dockerfile
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: |
+            org.opencontainers.image.created=(date +'%Y-%m-%dT%H:%M:%SZ')
+            org.opencontainers.image.url=https://github.com/rucio/jupyterlab-extension
+            org.opencontainers.image.title=rucio-jupyterlab
+            org.opencontainers.image.description=JupyterLab extension for Rucio
+            org.opencontainers.image.version=${{ steps.metadata.outputs.tags }}
+            


### PR DESCRIPTION
Solves #35 

This PR builds a docker image of the repository and publish it to dockerHub.

Ci works fine - tested on a [branch of my fork](https://github.com/garciagenrique/jupyterlab-extension/tree/fork-test_publish_docker_ci). See also the [CI action output](https://github.com/garciagenrique/jupyterlab-extension/actions/runs/13324890596) and the published image on [dockerhub/garciagenrique](https://hub.docker.com/repository/docker/garciagenrique/rucio-jupyterlab/general).

Few points to discuss/TODO:
 - [ ] @bari12 we would need to add the rucio docker hub credentials on as secrets of this repo. Could you add them, please?
 ```bash
      - name: Log into the Docker Hub
        id: login
        uses: docker/login-action@v3
        with:
          username: ${{ secrets.DOCKER_USERNAME }}
          password: ${{ secrets.DOCKER_PASSWORD }}
 ```
 - [ ] Image will be only published when a new version of the repository is created. Do we want to push images on every merge to master ? I would say yes. In case we publish the images on merges, which `tag` should we use for the image ? `:latest` ? `:sha-<SHORT_SHA>` ? both ?
