### PR TITLE
correct label typo and re trigger CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: |
             org.opencontainers.image.created=(date +'%Y-%m-%dT%H:%M:%SZ')
-            org.opencontainers.image.url=https://github.com/garciagenrique/jupyterlab-extension
+            org.opencontainers.image.url=https://github.com/rucio/jupyterlab-extension
             org.opencontainers.image.title=rucio-jupyterlab
             org.opencontainers.image.description=JupyterLab extension for Rucio
             org.opencontainers.image.version=${{ steps.metadata.outputs.tags }}


### PR DESCRIPTION
Correct typo on the docker labels and closes #35 

