### PR TITLE
fix(ci): update env secrets variables - fixes PR35 and PR45

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,10 +55,10 @@ jobs:
 
       - name: Log into the Docker Hub
         id: login
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.3.0
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Extract metadata for the Docker image
         id: metadata


### PR DESCRIPTION
And use same version for the `docker/login-action@v3.3.0` actions as rucio/containers repo.

Finally closes #35 