### PR TITLE
fix(ci): use same building and pushing steps as upstream rucio/containers repo

### DIFF
--- a/.github/workflows/build-and-publish-tagged.yml
+++ b/.github/workflows/build-and-publish-tagged.yml
@@ -46,25 +46,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.8.0
+
       - name: Log into the Docker Hub
         id: login
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.3.0
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Extract metadata for the Docker image
         id: metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v5.7.0
         with:
           flavor: |
             latest=true
           tags: |
             type=semver,pattern={{raw}}
-          images: rucio/rucio-jupyterlab
+          images: rucio/jupyterlab
 
       - name: Build and push the Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6.13.0
         id: docker_build
         with:
           context: .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.8.0
+
       - name: Log into the Docker Hub
         id: login
         uses: docker/login-action@v3.3.0
@@ -62,14 +65,14 @@ jobs:
 
       - name: Extract metadata for the Docker image
         id: metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v5.7.0
         with:
           tags: |
             type=ref,event=branch
-          images: rucio/rucio-jupyterlab
+          images: rucio/jupyterlab
 
       - name: Build and push the Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6.13.0
         id: docker_build
         with:
           context: .


### PR DESCRIPTION
Edit: Fixed name of the dockerHub image, which is `rucio/jupyterlab` and not `rucio/jupyterlab-extension`. 

Using same steps  as on the `rucio/containers` repository.
