### PR TITLE
feat(ci): add gh action to keep actions versions updated automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Following suggestion of @rdimaio on https://github.com/rucio/jupyterlab-extension/pull/47 and https://github.com/rucio/containers/pull/390/files

@bari12 could you please enable the dependanbot version updates ? Steps 2, 3 and 4 of https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-dependabot-version-updates 

Thanks !