### PR TITLE
fix(actions): avoid dependanbot update respoitory dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    ignore:
+      - dependency-type: "all"  # Ensures only GitHub Actions are updated


### PR DESCRIPTION
reference: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--

This PR should avoid that dependanbot creates dependencies PR, like #54 to #61 