### PR TITLE
fix(deps): relax rucio-clients dependencies - fixed on 97c3d0e

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "psutil",
     "pyjwt",
     "jsonschema",
-    "rucio-clients>=32.0,<35.2",
+    "rucio-clients>=32.0",
     "traitlets",
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]


### PR DESCRIPTION
Relaxing `rucio-clients` dependencies. 
Currently, when trying to install latest (or even 35.8.0) version of `rucio-clients`, we find this incompatibility.

```bash
python -m pip install rucio-clients==35.8.0     rucio-jupyterlab==1.3.0     && jupyter server extension enable --py rucio_jupyterlab --sys-prefix:
10.78 
10.78 The conflict is caused by:
10.78     The user requested rucio-clients==35.8.0
10.78     rucio-jupyterlab 1.3.0 depends on rucio-clients<35.2 and >=32.0
```

The `<35.2` upper pin incompatibility was solved within [97c3d0e](https://github.com/rucio/jupyterlab-extension/commit/97c3d0eb9e7a2c3b625a7449762ce0ef189ba67e).


Should we even remove the lower pin ? @ftorradeflot @Soap2G 