### PR TITLE
fix: matrix tests restructuring and update of container image to match py base version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -68,6 +68,12 @@ coverage.xml
 # Scrapy stuff:
 .scrapy
 
+# Environments
+env/
+venv/
+.env/
+.venv/
+
 # Sphinx documentation
 docs/_build/
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,9 +50,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+
+      - name: Upgrade packaging dependencies
+        run: pip install --upgrade pip pipx "hatch<1.16"
         
-      - name: Base Setup
-        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      # Using our custom setup instead of base-setup to support Python 3.9
         
       - name: Custom Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,12 @@ on:
   workflow_call:
 
 jobs:
-  Test:
-    name: Test
+  Test-Current:
+    name: Full Test
     strategy:
       matrix:
-        python-version: ["3.9", "3.11", "3.12"]
-        node-version: ["18.x", "20.x"]
+        python-version: ["3.12", "3.13"]
+        node-version: ["22.x", "24.x"]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -40,8 +40,58 @@ jobs:
             JLAB_BROWSER_TYPE: firefox
         uses: ./.github/actions/post-test
 
+  Test-Legacy:
+    name: Legacy Test
+    strategy:
+      matrix:
+        python-version: ["3.9"]
+        node-version: ["20.x"]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        
+      - name: Custom Setup
+        uses: ./.github/actions/setup
+        
+      - name: Build
+        uses: ./.github/actions/build-ext
+        
+      - name: Verify Installation (Smoke)
+        run: |
+          jupyter server extension list 2>&1 | grep -ie "rucio_jupyterlab.*OK"
+          jupyter labextension list 2>&1 | grep -ie "rucio-jupyterlab.*OK"
+      
+  Test-Edge:
+    name: Edge Test
+    strategy:
+      matrix:
+        python-version: ["3.14"]
+        node-version: ["24.x"]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        
+      - name: Custom Setup
+        uses: ./.github/actions/setup
+        
+      - name: Build
+        uses: ./.github/actions/build-ext
+        
+      - name: Verify Installation (Smoke)
+        run: |
+          jupyter server extension list 2>&1 | grep -ie "rucio_jupyterlab.*OK"
+          jupyter labextension list 2>&1 | grep -ie "rucio-jupyterlab.*OK"
+
   Build-docker:
-    needs: [Test]
+    needs: [Test-Current, Test-Legacy, Test-Edge]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
 

--- a/docker/container/Dockerfile
+++ b/docker/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/jupyter/docker-stacks-foundation:python-3.11
+FROM quay.io/jupyter/docker-stacks-foundation:python-3.12
 LABEL maintainer="Muhammad Aditya Hilmy <mhilmy@hey.com>, Francesc Torradeflot <torradeflot@pic.es>"
 
 ENV CONTAINER_PURPOSE="test"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
 [build-system]
-requires = ["hatchling>=1.5.0, <=1.18.0", "jupyterlab>=4.0.0,<5", "hatch-nodejs-version>=0.3.2"]
+requires = [
+    "hatchling<1.16.0; python_version == '3.9'",
+    "hatchling>=1.5.0, <=1.18.0; python_version >= '3.10'",
+    "jupyterlab>=4.0.0,<5",
+    "hatch-nodejs-version>=0.3.2"
+]
 build-backend = "hatchling.build"
 
 [project]
@@ -20,6 +25,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "jupyter_server>=2.0.1,<3",


### PR DESCRIPTION
Closes #122 
Closes #125

Updated the tests to support 3 schemas: 
- Legacy: python=3.9, node=20
- Current: python=[3.12, 3.13], node=22
- Edge: python=3.14, node=24

During the `mamba install` step, conda-forge implicitly upgrades `libxml2` to >=2.13.0, which replaces `libxml2.so.2` with `libxml2.so.16`. However, the `mamba` binary in the `jupyter/docker-stacks-foundation` base image dynamically links to `libxml2.so.2` via `libmambapy`.

By updating the base image to py3.12 (to support the main py version in the tests), this incompaibility was solved.