### PR TITLE
chore: Inherit secrets in build-and-publish workflow

### DIFF
--- a/.github/workflows/build-and-publish-tagged.yml
+++ b/.github/workflows/build-and-publish-tagged.yml
@@ -13,6 +13,7 @@ jobs:
 
   Test:
     uses: ./.github/workflows/test.yml
+    secrets: inherit
     
   Build:
     needs: [Test]


### PR DESCRIPTION
This is necessary as when triggering a manual action, the secrets are not propagated by default. 

Then there is the question of whether we want to keep all the build-docker stages (pushing both `master` and `release` tags), or only the releases.

The `build-docker` action in Tests pushes the `master` tag, while the same action in `build-and-publish-tagged.yml` pushes the release.

@bari12 @ftorradeflot do you have any preferences on the docker push? 