### PR TITLE
Stop ignored npm Dependabot jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: weekly
-    ignore:
-      - dependency-name: "*"


### PR DESCRIPTION
## Summary

This removes the npm Dependabot updater that is configured with `ignore: "*"`.

## Why

Issue #123 shows the `npm_and_yarn` Dependabot jobs failing for npm packages even though this repo appears to intentionally ignore all npm dependency updates. Keeping the `github-actions` updater but removing the ignored npm ecosystem should stop those noisy jobs without changing package code or CI workflows.

## Scope

- No dependency updates
- No workflow changes
- Only `.github/dependabot.yml`

If you'd prefer to keep npm Dependabot enabled later, the alternative would be to remove the blanket ignore and triage the package updates individually.
