### PR TITLE
fix: posix style did names and download diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rucio-jupyterlab",
-  "version": "41.0.0",
+  "version": "41.0.2",
   "description": "JupyterLab extension for integrating Rucio",
   "keywords": [
     "jupyter",

--- a/rucio_jupyterlab/handlers/did_browser.py
+++ b/rucio_jupyterlab/handlers/did_browser.py
@@ -103,7 +103,7 @@ class DIDBrowserHandler(RucioAPIHandler):
         logger.debug("Query arguments - Namespace: %s, Poll: %s, DID: %s", namespace, poll, did)
 
         rucio = self.rucio.for_instance(namespace)
-        (scope, name) = did.split(':')
+        (scope, name) = did.split(':', 1)
         logger.debug("Split DID into scope: %s, name: %s", scope, name)
 
         handler = DIDBrowserHandlerImpl(namespace, rucio)

--- a/rucio_jupyterlab/handlers/did_details.py
+++ b/rucio_jupyterlab/handlers/did_details.py
@@ -40,7 +40,7 @@ class DIDDetailsHandler(RucioAPIHandler):
         namespace = self.get_query_argument('namespace')
         force_refresh = self.get_query_argument('force', '0') == '1'
         did = self.get_query_argument('did')
-        scope, name = did.split(':')
+        scope, name = did.split(':', 1)
 
         rucio_instance = self.rucio.for_instance(namespace)
         mode = rucio_instance.instance_config.get('mode', 'replica')

--- a/rucio_jupyterlab/handlers/did_make_available.py
+++ b/rucio_jupyterlab/handlers/did_make_available.py
@@ -47,7 +47,7 @@ class DIDMakeAvailableHandler(RucioAPIHandler):
         did = json_body['did']
         logger.debug("DID: %s", did)
 
-        scope, name = did.split(':')
+        scope, name = did.split(':', 1)
         logger.debug("Scope: %s, Name: %s", scope, name)
 
         rucio_instance = self.rucio.for_instance(namespace)

--- a/rucio_jupyterlab/handlers/did_search.py
+++ b/rucio_jupyterlab/handlers/did_search.py
@@ -114,7 +114,7 @@ class DIDSearchHandler(RucioAPIHandler):
         rucio = self.rucio.for_instance(namespace)
 
         try:
-            (scope, name) = did.split(':')
+            (scope, name) = did.split(':', 1)
             if not scope or not name:
                 raise ValueError()
         except ValueError as e:

--- a/rucio_jupyterlab/mode_handlers/download.py
+++ b/rucio_jupyterlab/mode_handlers/download.py
@@ -109,7 +109,7 @@ class DownloadModeHandler:
         except Exception as e:
             # Handle any other unexpected errors
             logger.exception("An unexpected error occurred in make_available for DID '%s'", did)
-            RucioFileDownloader.write_errorfile(dest_folder, e)
+            RucioFileDownloader.write_errorfile(dest_folder, e, getattr(self.rucio, 'instance_config', None))
             RucioFileDownloader.delete_lockfile(dest_folder)
             raise
 

--- a/rucio_jupyterlab/rucio/download.py
+++ b/rucio_jupyterlab/rucio/download.py
@@ -30,7 +30,40 @@ def rucio_logger(level, msg, *args, **kwargs):
 
 class RucioFileDownloader:
     @staticmethod
-    def write_errorfile(dest_folder, exception):
+    def diagnose(exception, instance_config=None):
+        """
+        Returns a human-readable hint for download failures whose root cause is not
+        apparent from the exception text, or None when there is nothing to add.
+        """
+        name = exception.__class__.__name__
+        text = str(exception)
+
+        if name == 'CannotAuthenticate' or 'Cannot authenticate' in text:
+            vo = (instance_config or {}).get('vo')
+            if vo:
+                # The API path authenticates without a VO, so browsing succeeds even when
+                # `vo` is wrong; the download client is the first thing to actually use it.
+                return (f"The instance is configured with vo='{vo}', which is sent by the download "
+                        f"client but not by the API calls used for browsing. A wrong vo therefore "
+                        f"fails only here. Verify it matches the server, or remove it for single-VO Rucio.")
+
+        if name == 'MissingDependency' or 'dependency is missing' in text:
+            return ("A transfer library required by the storage protocol is not installed. "
+                    "Download mode needs the RSE protocol backends, typically gfal2 "
+                    "(conda: 'python-gfal2', RPM: 'gfal2-all gfal2-python'). Note that a "
+                    "system-installed gfal2 is not visible from a virtualenv unless it was "
+                    "created with --system-site-packages and the same Python version.")
+
+        if name == 'NoFilesDownloaded' or 'none of the requested files' in text.lower():
+            return ("No file could be retrieved from any source. Common causes: the transfer "
+                    "library for the RSE protocol is missing (see gfal2 above), or the storage "
+                    "endpoint is not reachable from this host. Re-run with debug logging to see "
+                    "the per-PFN reason.")
+
+        return None
+
+    @staticmethod
+    def write_errorfile(dest_folder, exception, instance_config=None):
         """
         Writes exception details to an error.json file in the destination folder.
         """
@@ -46,12 +79,18 @@ class RucioFileDownloader:
             'exception_message': str(exception)
         }
 
+        hint = RucioFileDownloader.diagnose(exception, instance_config)
+        if hint:
+            error_payload['hint'] = hint
+            error_payload['exception_message'] = f"{error_payload['exception_message']}\nHint: {hint}"
+
         logger.error("Writing error file to '%s' with details: %s", error_file_path, error_payload)
         with open(error_file_path, 'w') as f:
             json.dump(error_payload, f)
 
     def start_download_target(namespace, did, rucio):
         dest_folder = RucioFileDownloader.get_dest_folder(namespace, did)
+        instance_config = getattr(rucio, 'instance_config', None)
         logger.info("Preparing to download DID '%s' to '%s'.", did, dest_folder)
 
         try:
@@ -67,7 +106,7 @@ class RucioFileDownloader:
                 except Exception as e:
                     # Log the exception and write the error file
                     logger.exception("Download failed for DID '%s': %s", did, e)
-                    RucioFileDownloader.write_errorfile(dest_folder, e)
+                    RucioFileDownloader.write_errorfile(dest_folder, e, instance_config)
 
                 finally:
                     # Always remove the lockfile when the operation is complete (or has failed)
@@ -79,7 +118,7 @@ class RucioFileDownloader:
             logger.error("A critical error occurred before download could start for DID '%s': %s", did, e)
             # Ensure the destination folder exists to write the error file
             os.makedirs(dest_folder, exist_ok=True)
-            RucioFileDownloader.write_errorfile(dest_folder, e)
+            RucioFileDownloader.write_errorfile(dest_folder, e, instance_config)
             RucioFileDownloader.delete_lockfile(dest_folder)
 
     @staticmethod

--- a/rucio_jupyterlab/rucio/rucio.py
+++ b/rucio_jupyterlab/rucio/rucio.py
@@ -360,6 +360,17 @@ class RucioAPI:
         app_id = self.instance_config.get('app_id')
         vo = self.instance_config.get('vo')
 
+        # The token endpoints below are deliberately called without a VO (see the TODOs).
+        # The download client, however, does receive `vo` via the generated rucio.cfg, so a
+        # wrong `vo` is invisible while browsing and only surfaces as an opaque
+        # "Cannot authenticate" once a download starts. Say so up front.
+        if vo and auth_type in ('userpass', 'x509', 'x509_proxy'):
+            logger.warning(
+                "Instance '%s' sets vo='%s', but %s authentication is performed without a VO. "
+                "Only the download client uses it, so an incorrect vo fails at download time only.",
+                self.instance_config.get('name'), vo, auth_type
+            )
+
         try:
             if auth_type == 'userpass':
                 username = auth_config.get('username')

--- a/rucio_jupyterlab/rucio/rucio.py
+++ b/rucio_jupyterlab/rucio/rucio.py
@@ -162,29 +162,40 @@ class RucioAPI:
         self.auth_url = instance_config.get('rucio_auth_url', self.base_url)
         self.rucio_ca_cert = instance_config.get('rucio_ca_cert', True)    # Default should be True to use system CA certs
 
-    def _build_url(self, endpoint, scope=None, name=None):
+    def _build_url(self, endpoint, scope=None, name=None, suffix=None):
         """
         Constructs the URL path, without query parameters.
+
+        Scope and name are percent-encoded with `safe=''` so that a DID name
+        containing slashes (POSIX-like naming, e.g. 'tumour/purity_0.3') stays a
+        single path segment. Rucio unquotes the segment server-side to split
+        scope from name; leaving the slashes bare makes it fail with
+        "Could not parse ... with encoded '/' into scope and name".
+
+        `suffix` holds sub-resource paths ('/files', '/meta', ...) that must
+        remain real path separators, so it is appended unencoded.
         """
         # Use strip('/') to avoid issues like 'host//endpoint'
         url_parts = []
         if endpoint:
             url_parts.append(endpoint)
         if scope:
-            url_parts.append(quote(scope))
+            url_parts.append(quote(scope, safe=''))
         if name:
-            url_parts.append(quote(name))
+            url_parts.append(quote(name, safe=''))
 
         # Join url parts and replace multiple slashes with a single slash
         url_path = re.sub("/{2,}", "/", "/".join(url_parts))
+        if suffix:
+            url_path = url_path + '/' + suffix.strip('/')
         return  urljoin(self.base_url, url_path)
 
     def _make_rucio_request(self, method, endpoint, scope=None, name=None, params=None, data=None,
-                            parse_json=False, parse_lines=False):
+                            parse_json=False, parse_lines=False, suffix=None):
         """
         Centralizes logic for making Rucio API requests and handling errors.
         """
-        url = self._build_url(endpoint, scope, name)
+        url = self._build_url(endpoint, scope, name, suffix)
 
         try:
             token = self._get_auth_token()
@@ -262,7 +273,7 @@ class RucioAPI:
 
         results = self._make_rucio_request(
             'GET',
-            f'dids/{scope}/dids/search',
+            f'dids/{quote(scope, safe="")}/dids/search',
             params=params,
             parse_json=True,
             parse_lines=True
@@ -274,19 +285,19 @@ class RucioAPI:
 
     def get_metadata(self, scope, name):
         # DEBUG: response = requests.get(url=f'{self.base_url}/dids/{scope}/{name}/meta', headers=headers, verify=self.rucio_ca_cert)
-        return self._make_rucio_request('GET', 'dids', scope, name + '/meta', parse_lines=True)
+        return self._make_rucio_request('GET', 'dids', scope, name, suffix='meta', parse_lines=True)
 
     def get_files(self, scope, name):
         # DEBUG: response = requests.get(url=f'{self.base_url}/dids/{scope}/{name}/files', headers=headers, verify=self.rucio_ca_cert)
-        return self._make_rucio_request('GET', 'dids', scope, name + '/files', parse_json=True, parse_lines=True)
+        return self._make_rucio_request('GET', 'dids', scope, name, suffix='files', parse_json=True, parse_lines=True)
 
     def get_parents(self, scope, name):
         # DEBUG: response = requests.get(url=f'{self.base_url}/dids/{scope}/{name}/parents', headers=headers, verify=self.rucio_ca_cert)
-        return self._make_rucio_request('GET', 'dids', scope, name + '/parents', parse_json=True, parse_lines=True)
+        return self._make_rucio_request('GET', 'dids', scope, name, suffix='parents', parse_json=True, parse_lines=True)
 
     def get_rules(self, scope, name):
         # DEBUG: response = requests.get(url=f'{self.base_url}/dids/{scope}/{name}/rules', headers=headers, verify=self.rucio_ca_cert)
-        return self._make_rucio_request('GET', 'dids', scope, name + '/rules', parse_json=True, parse_lines=True)
+        return self._make_rucio_request('GET', 'dids', scope, name, suffix='rules', parse_json=True, parse_lines=True)
 
     def get_rule_details(self, rule_id):
         # DEBUG: response = requests.get(url=f'{self.base_url}/rules/{rule_id}', headers=headers, verify=self.rucio_ca_cert)
@@ -348,6 +359,7 @@ class RucioAPI:
 
         app_id = self.instance_config.get('app_id')
         vo = self.instance_config.get('vo')
+
         try:
             if auth_type == 'userpass':
                 username = auth_config.get('username')

--- a/rucio_jupyterlab/tests/test_rucio_api.py
+++ b/rucio_jupyterlab/tests/test_rucio_api.py
@@ -218,3 +218,46 @@ def test_add_replication_rule(rucio, mocker, requests_mock):
                         'asynchronous': mock_asynchronous, 'priority': mock_priority, 'meta': mock_meta}
 
     assert adapter.last_request.json() == expected_request, "Invalid request payload"
+
+
+# --- DID names containing slashes (POSIX-like naming) ---------------------
+#
+# Rucio packs scope and name into a single path segment and unquotes it
+# server-side, so a '/' inside the name must be sent as '%2F'. Sending it raw
+# makes Rucio answer 400 "Could not parse ... with encoded '/' into scope and
+# name".
+
+SLASHED_NAME = 'tumour/purity_0.3/TIME'
+ENCODED_NAME = 'tumour%2Fpurity_0.3%2FTIME'
+
+
+def test_build_url_encodes_slashes_in_name(rucio):
+    url = rucio._build_url('dids', 'SPN01', SLASHED_NAME, suffix='files')  # pylint: disable=protected-access
+    assert url == f'{MOCK_BASE_URL}/dids/SPN01/{ENCODED_NAME}/files', "Slash in DID name must be percent-encoded"
+
+
+def test_get_files_with_slashed_name(rucio, mocker, requests_mock):
+    mocker.patch('rucio_jupyterlab.rucio.rucio.authenticate_userpass', return_value=(MOCK_AUTH_TOKEN, 1368440583))
+
+    mock_response_json = [{'scope': 'SPN01', 'name': f'{SLASHED_NAME}/out_0.root', 'bytes': 1196}]
+    mock_response = '\n'.join([json.dumps(x) for x in mock_response_json])
+
+    adapter = requests_mock.get(f"{MOCK_BASE_URL}/dids/SPN01/{ENCODED_NAME}/files",
+                                request_headers={'X-Rucio-Auth-Token': MOCK_AUTH_TOKEN}, text=mock_response)
+    response = rucio.get_files('SPN01', SLASHED_NAME)
+
+    assert response == mock_response_json, "Invalid response"
+    assert adapter.last_request.path_url == f'/dids/SPN01/{ENCODED_NAME}/files', "Invalid request path"
+
+
+def test_get_replicas_with_slashed_name(rucio, mocker, requests_mock):
+    mocker.patch('rucio_jupyterlab.rucio.rucio.authenticate_userpass', return_value=(MOCK_AUTH_TOKEN, 1368440583))
+
+    mock_response_json = [{'scope': 'SPN01', 'name': SLASHED_NAME, 'states': {'XRD1': 'AVAILABLE'}}]
+    mock_response = '\n'.join([json.dumps(x) for x in mock_response_json])
+
+    requests_mock.get(f"{MOCK_BASE_URL}/replicas/SPN01/{ENCODED_NAME}",
+                      request_headers={'X-Rucio-Auth-Token': MOCK_AUTH_TOKEN}, text=mock_response)
+    response = rucio.get_replicas('SPN01', SLASHED_NAME)
+
+    assert response == mock_response_json, "Invalid response"

--- a/rucio_jupyterlab/tests/test_rucio_file_downloader.py
+++ b/rucio_jupyterlab/tests/test_rucio_file_downloader.py
@@ -9,6 +9,7 @@
 # - Giovanni Guerrieri, <giovanni.guerrieri@cern.ch>, 2025
 
 import os
+import json
 from unittest.mock import patch, mock_open
 import psutil
 from rucio_jupyterlab.rucio.download import RucioFileDownloader
@@ -123,3 +124,56 @@ def test_rucio_file_downloader_write_lockfile__should_write_pid(mocker):
 
     # Verify return value
     assert result is True
+
+
+# --- Failure diagnostics -------------------------------------------------
+#
+# These failures are opaque in practice: a wrong `vo` is only ever exercised by the
+# download client (the API path authenticates without a VO), and a missing gfal2 shows
+# up as a generic "no files downloaded". Both cost real debugging time, so the cause is
+# attached to the error file the UI reads.
+
+class CannotAuthenticate(Exception):
+    pass
+
+
+class MissingDependency(Exception):
+    pass
+
+
+class NoFilesDownloaded(Exception):
+    pass
+
+
+def test_diagnose_cannot_authenticate_mentions_configured_vo():
+    hint = RucioFileDownloader.diagnose(CannotAuthenticate('Cannot authenticate.'), {'vo': 'escape'})
+    assert hint is not None, "CannotAuthenticate with a configured vo must produce a hint"
+    assert "vo='escape'" in hint, "Hint must name the configured vo"
+
+
+def test_diagnose_cannot_authenticate_without_vo_gives_no_vo_hint():
+    hint = RucioFileDownloader.diagnose(CannotAuthenticate('Cannot authenticate.'), {})
+    assert hint is None, "Without a configured vo there is no vo-related hint to give"
+
+
+def test_diagnose_missing_dependency_mentions_gfal2():
+    hint = RucioFileDownloader.diagnose(MissingDependency('One dependency is missing.'), {})
+    assert hint is not None and 'gfal2' in hint, "MissingDependency must point at the transfer library"
+
+
+def test_diagnose_no_files_downloaded_is_actionable():
+    hint = RucioFileDownloader.diagnose(NoFilesDownloaded('None of the requested files have been downloaded.'), {})
+    assert hint is not None and 'gfal2' in hint, "NoFilesDownloaded must suggest the usual causes"
+
+
+def test_diagnose_unknown_exception_returns_none():
+    assert RucioFileDownloader.diagnose(ValueError('something else'), {'vo': 'escape'}) is None
+
+
+def test_write_errorfile_embeds_hint(tmp_path):
+    dest = str(tmp_path / 'dl')
+    RucioFileDownloader.write_errorfile(dest, CannotAuthenticate('Cannot authenticate.'), {'vo': 'escape'})
+    with open(os.path.join(dest, 'error.json')) as f:
+        payload = json.load(f)
+    assert 'hint' in payload, "error.json must carry the hint for the UI"
+    assert "vo='escape'" in payload['exception_message'], "Message shown to the user must include the hint"


### PR DESCRIPTION
DID names containing slashes made the extension hang on fetch. 

As an example (coming from an EOSC use case):

```
GET /dids/SPN01/tumour/purity_0.3/files
400 BAD REQUEST
Could not parse 'SPN01/tumour/purity_0.3' (scope_name='SPN01/tumour/purity_0.3') with encoded '/' into scope and name.
```
Looks like `_build_url` percent-encoded the DID name with urllib's default `safe='/'`, so slashes survived into the URL. Rucio packs scope and name into a single path segment and unquotes it server-side to split them again, so a bare / makes the boundary ambiguous.

The fix is to support POSIX-style DID names. 
Quote scope and name with `safe=''`, and move the sub-resource suffixes (/files, /meta, /parents, /rules) out of the name argument into a `suffix` parameter so those stay path separators. 

Then, a feat: download-mode diagnostics. 

A wrong VO authenticates fine while browsing (the token endpoints are called without a VO, still a TODO) but is passed to the download client via the generated rucio.cfg, so it surfaces only as very vague `CannotAuthenticate` once a download starts. 

Also, if `gfal2` is missing, there's no meaningful warning. 
`RucioFileDownloader.diagnose()` should take care of that by attaching a hint to `error.json` so the cause reaches the UI.